### PR TITLE
fix scriptExtension imports

### DIFF
--- a/Core/automation/jsr223/python/core/components/100_DirectoryTrigger.py
+++ b/Core/automation/jsr223/python/core/components/100_DirectoryTrigger.py
@@ -5,7 +5,10 @@ directory for new files and then process them.
 """
 from java.nio.file.StandardWatchEventKinds import ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY
 
-scriptExtension.importPreset(None)# fix for compatibility with Jython > 2.7.0
+try:
+    scriptExtension.importPreset(None)# fix for compatibility with Jython > 2.7.0
+except:
+    pass
 
 try:
     from org.openhab.core.automation.handler import TriggerHandler

--- a/Core/automation/lib/python/core/items.py
+++ b/Core/automation/lib/python/core/items.py
@@ -5,7 +5,10 @@ any links from an Item before it is removed.
 __all__ = ["add_item", "remove_item"]
 
 from core.jsr223.scope import scriptExtension, itemRegistry
-scriptExtension.importPreset(None)
+try:
+    scriptExtension.importPreset(None)
+except:
+    pass
 
 import core
 from core import osgi


### PR DESCRIPTION
Restore fix for OH3 throwing NPE when trying to import preset `null` (`None`)

@jimtng you removed these in your initial patch, but in my tests I was not seeing any issues with them. I was adding in one of my modules that uses `core.items` and was getting weird errors and NPE errors from `100_DirectoryTrigger.py`. I don't know if those NPEs were there before, but if they were I didnt see them. I have tested this approach with the try statements and it works.

Signed-off-by: Michael Murton <6764025+CrazyIvan359@users.noreply.github.com>