### PR TITLE
validate_item updates

### DIFF
--- a/Core/automation/lib/python/core/utils.py
+++ b/Core/automation/lib/python/core/utils.py
@@ -39,7 +39,7 @@ from java.time import ZonedDateTime
 
 from core.date import to_java_zoneddatetime, to_joda_datetime
 from core.log import logging, LOG_PREFIX
-from core.jsr223.scope import itemRegistry, NULL, UNDEF, ON, OFF, OPEN, CLOSED, events, things
+from core.jsr223.scope import itemRegistry, StringType, NULL, UNDEF, ON, OFF, OPEN, CLOSED, events, things
 
 
 LOG = logging.getLogger(u"{}.core.utils".format(LOG_PREFIX))
@@ -57,14 +57,14 @@ def validate_item(item_or_item_name):
         in a valid format, else validated Item
     """
     item = item_or_item_name
-    if isinstance(item, basestring):
-        if itemRegistry.getItems(item) == []:
-            LOG.warn(u"'{}' is not in the ItemRegistry".format(item))
+    if isinstance(item, (basestring, unicode, StringType)):
+        if itemRegistry.getItems(str(item)) == []:
+            LOG.warn(u"'{}' is not in the ItemRegistry".format(str(item)))
             return None
         else:
-            item = itemRegistry.getItem(item_or_item_name)
-    elif not hasattr(item_or_item_name, 'name'):
-        LOG.warn(u"'{}' is not a Item or string".format(item))
+            item = itemRegistry.getItem(str(item))
+    elif not hasattr(item, 'name'):
+        LOG.warn(u"'{}' is not a Item or string".format(str(item)))
         return None
 
     if itemRegistry.getItems(item.name) == []:


### PR DESCRIPTION
This updates `core.utils.validate_item` to handle unicode strings (I seem to be getting those more than plain strings in OH3) and adds ability to pass a `StringType` item name as well.

Signed-off-by: Michael Murton <6764025+CrazyIvan359@users.noreply.github.com>